### PR TITLE
fix: harden heartbeat scheduling and cron uniqueness

### DIFF
--- a/db/migrations/021_enforce_unique_cron_schedule_names.sql
+++ b/db/migrations/021_enforce_unique_cron_schedule_names.sql
@@ -1,0 +1,27 @@
+-- 021: Enforce unique cron schedule names.
+--
+-- Why:
+-- - ops_cron_schedules historically allowed duplicate names.
+-- - heartbeat scheduler iterates all enabled rows, so duplicate names can double-fire.
+--
+-- Behavior:
+-- 1) Deduplicate by name, keeping the newest row (updated_at/created_at/id desc).
+-- 2) Add a UNIQUE index on (name) to prevent recurrence.
+
+WITH ranked AS (
+    SELECT
+        id,
+        name,
+        ROW_NUMBER() OVER (
+            PARTITION BY name
+            ORDER BY updated_at DESC, created_at DESC, id DESC
+        ) AS rn
+    FROM ops_cron_schedules
+)
+DELETE FROM ops_cron_schedules s
+USING ranked r
+WHERE s.id = r.id
+  AND r.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ops_cron_schedules_name
+ON ops_cron_schedules (name);

--- a/scripts/heartbeat-cron.sh
+++ b/scripts/heartbeat-cron.sh
@@ -1,29 +1,33 @@
 #!/usr/bin/env bash
-# Heartbeat cron script — calls /api/ops/heartbeat on the subcult-corp-app container
-# Install: crontab -e → */5 * * * * /mnt/spektr/server/projects/subcult-corp/scripts/heartbeat-cron.sh >> /tmp/subcult-heartbeat.log 2>&1
+# Heartbeat cron script — calls /api/ops/heartbeat via docker compose exec.
+# Install: crontab -e → */2 * * * * /mnt/spektr/server/projects/subcult-corp/scripts/heartbeat-cron.sh >> /tmp/subcult-heartbeat.log 2>&1
 
 set -euo pipefail
 
-CONTAINER="subcult-corp-app"
-PORT=3000
-CRON_SECRET="3354b9f3d32874ad10a615589c69c2d0eebfe60952148c22ea469a9d527d7550"
+SERVICE="subcult-corp-app"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$PROJECT_ROOT/.env"
 
-# Resolve container IP on the projects network
-IP=$(docker inspect "$CONTAINER" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' 2>/dev/null | awk '{print $1}')
-
-if [ -z "$IP" ]; then
-    echo "$(date -Iseconds) ERROR: Container $CONTAINER not running"
+if [ ! -f "$ENV_FILE" ]; then
+    echo "$(date -Iseconds) ERROR: Missing env file at $ENV_FILE"
     exit 1
 fi
 
-echo "$(date -Iseconds) Calling heartbeat at $IP:$PORT..."
-HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
-    --max-time 300 \
-    -H "Authorization: Bearer $CRON_SECRET" \
-    "http://$IP:$PORT/api/ops/heartbeat")
-
-echo "$(date -Iseconds) Heartbeat response: HTTP $HTTP_CODE"
-
-if [ "$HTTP_CODE" != "200" ]; then
+CRON_SECRET="$(grep '^CRON_SECRET=' "$ENV_FILE" | tail -n 1 | cut -d= -f2-)"
+if [ -z "$CRON_SECRET" ]; then
+    echo "$(date -Iseconds) ERROR: CRON_SECRET missing in $ENV_FILE"
     exit 1
 fi
+
+cd "$PROJECT_ROOT"
+
+echo "$(date -Iseconds) Calling heartbeat via docker compose service $SERVICE..."
+if ! RESPONSE="$(docker compose exec -T "$SERVICE" wget -qO- \
+    --header="Authorization: Bearer $CRON_SECRET" \
+    "http://127.0.0.1:3000/api/ops/heartbeat")"; then
+    echo "$(date -Iseconds) ERROR: heartbeat request failed"
+    exit 1
+fi
+
+echo "$(date -Iseconds) Heartbeat response body: $RESPONSE"

--- a/scripts/heartbeat-cron.sh
+++ b/scripts/heartbeat-cron.sh
@@ -23,11 +23,14 @@ fi
 cd "$PROJECT_ROOT"
 
 echo "$(date -Iseconds) Calling heartbeat via docker compose service $SERVICE..."
-if ! RESPONSE="$(docker compose exec -T "$SERVICE" wget -qO- \
-    --header="Authorization: Bearer $CRON_SECRET" \
-    "http://127.0.0.1:3000/api/ops/heartbeat")"; then
+if ! STATUS_CODE="$(docker compose exec -T "$SERVICE" sh -c '
+    wget -S -q -O /dev/null \
+        --header="Authorization: Bearer '"'"$1"'"'" \
+        "http://127.0.0.1:3000/api/ops/heartbeat" 2>&1 |
+    awk "/^  HTTP\\// { code = \$2 } END { if (code != \"\") print code; else exit 1 }"
+' sh "$CRON_SECRET")"; then
     echo "$(date -Iseconds) ERROR: heartbeat request failed"
     exit 1
 fi
 
-echo "$(date -Iseconds) Heartbeat response body: $RESPONSE"
+echo "$(date -Iseconds) Heartbeat status: $STATUS_CODE"

--- a/scripts/heartbeat-cron.sh
+++ b/scripts/heartbeat-cron.sh
@@ -14,7 +14,7 @@ if [ ! -f "$ENV_FILE" ]; then
     exit 1
 fi
 
-CRON_SECRET="$(grep '^CRON_SECRET=' "$ENV_FILE" | tail -n 1 | cut -d= -f2-)"
+CRON_SECRET="$(grep '^CRON_SECRET=' "$ENV_FILE" | tail -n 1 | cut -d= -f2- || true)"
 if [ -z "$CRON_SECRET" ]; then
     echo "$(date -Iseconds) ERROR: CRON_SECRET missing in $ENV_FILE"
     exit 1

--- a/scripts/migrate-cron-jobs.ts
+++ b/scripts/migrate-cron-jobs.ts
@@ -273,15 +273,6 @@ async function main() {
     log.info('Starting cron jobs migration', { count: JOBS.length });
 
     for (const job of JOBS) {
-        const [existing] = await sql`
-            SELECT id FROM ops_cron_schedules WHERE name = ${job.name}
-        `;
-
-        if (existing) {
-            log.debug('Skipping existing job', { name: job.name });
-            continue;
-        }
-
         const nextFireAt = computeNextFireAt(
             job.cron_expression,
             'America/Chicago',
@@ -300,9 +291,20 @@ async function main() {
                 enabled: true,
                 next_fire_at: nextFireAt.toISOString(),
             })}
+            ON CONFLICT (name) DO UPDATE SET
+                agent_id = EXCLUDED.agent_id,
+                cron_expression = EXCLUDED.cron_expression,
+                timezone = EXCLUDED.timezone,
+                prompt = EXCLUDED.prompt,
+                timeout_seconds = EXCLUDED.timeout_seconds,
+                max_tool_rounds = EXCLUDED.max_tool_rounds,
+                model = EXCLUDED.model,
+                enabled = EXCLUDED.enabled,
+                next_fire_at = EXCLUDED.next_fire_at,
+                updated_at = NOW()
         `;
 
-        log.info('Created cron job', {
+        log.info('Upserted cron job', {
             name: job.name,
             agent_id: job.agent_id,
             schedule: job.cron_expression,

--- a/src/lib/ops/cron-scheduler.ts
+++ b/src/lib/ops/cron-scheduler.ts
@@ -6,16 +6,27 @@ import { logger } from '@/lib/logger';
 
 const log = logger.child({ module: 'cron-scheduler' });
 
+const timeFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getTimeFormatter(timezone: string): Intl.DateTimeFormat {
+    let formatter = timeFormatterCache.get(timezone);
+    if (!formatter) {
+        formatter = new Intl.DateTimeFormat('en-US', {
+            timeZone: timezone,
+            hour: 'numeric',
+            minute: 'numeric',
+            weekday: 'short',
+            day: 'numeric',
+            month: 'numeric',
+            hour12: false,
+        });
+        timeFormatterCache.set(timezone, formatter);
+    }
+    return formatter;
+}
+
 function getTimeParts(date: Date, timezone: string) {
-    const formatter = new Intl.DateTimeFormat('en-US', {
-        timeZone: timezone,
-        hour: 'numeric',
-        minute: 'numeric',
-        weekday: 'short',
-        day: 'numeric',
-        month: 'numeric',
-        hour12: false,
-    });
+    const formatter = getTimeFormatter(timezone);
     return Object.fromEntries(formatter.formatToParts(date).map(p => [p.type, p.value]));
 }
 

--- a/src/lib/ops/cron-scheduler.ts
+++ b/src/lib/ops/cron-scheduler.ts
@@ -6,14 +6,7 @@ import { logger } from '@/lib/logger';
 
 const log = logger.child({ module: 'cron-scheduler' });
 
-/**
- * Parse a cron expression and check if it should have fired between lastFired and now.
- * Simple cron check: compare current minute against cron fields.
- * Uses a basic parser to avoid adding cron-parser as a dependency.
- */
-function shouldFire(cronExpr: string, timezone: string, lastFiredAt: string | null): boolean {
-    // Get current time in the schedule's timezone
-    const now = new Date();
+function getTimeParts(date: Date, timezone: string) {
     const formatter = new Intl.DateTimeFormat('en-US', {
         timeZone: timezone,
         hour: 'numeric',
@@ -23,37 +16,67 @@ function shouldFire(cronExpr: string, timezone: string, lastFiredAt: string | nu
         month: 'numeric',
         hour12: false,
     });
-    const parts = Object.fromEntries(
-        formatter.formatToParts(now).map(p => [p.type, p.value])
-    );
+    return Object.fromEntries(formatter.formatToParts(date).map(p => [p.type, p.value]));
+}
 
-    const currentMinute = parseInt(parts.minute ?? '0');
-    const currentHour = parseInt(parts.hour ?? '0');
-    const currentDow = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
-        .indexOf(parts.weekday ?? 'Mon');
-    const currentDom = parseInt(parts.day ?? '1');
-    const currentMonth = parseInt(parts.month ?? '1');
-
-    // Parse cron: minute hour dom month dow
+function matchesCronAt(cronExpr: string, timezone: string, date: Date): boolean {
     const fields = cronExpr.trim().split(/\s+/);
     if (fields.length < 5) return false;
-
     const [minField, hourField, domField, monthField, dowField] = fields;
 
-    if (!matchField(minField, currentMinute, 0, 59)) return false;
-    if (!matchField(hourField, currentHour, 0, 23)) return false;
-    if (!matchField(domField, currentDom, 1, 31)) return false;
-    if (!matchField(monthField, currentMonth, 1, 12)) return false;
-    if (!matchField(dowField, currentDow, 0, 6)) return false;
+    const parts = getTimeParts(date, timezone);
+    const minute = parseInt(parts.minute ?? '0');
+    const hour = parseInt(parts.hour ?? '0');
+    const dow = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].indexOf(parts.weekday ?? 'Mon');
+    const dom = parseInt(parts.day ?? '1');
+    const month = parseInt(parts.month ?? '1');
 
-    // Prevent double-firing: check if we already fired in this minute
-    if (lastFiredAt) {
-        const lastFired = new Date(lastFiredAt);
-        const msSinceFired = now.getTime() - lastFired.getTime();
-        if (msSinceFired < 60_000) return false; // fired less than 1 min ago
+    return (
+        matchField(minField, minute, 0, 59) &&
+        matchField(hourField, hour, 0, 23) &&
+        matchField(domField, dom, 1, 31) &&
+        matchField(monthField, month, 1, 12) &&
+        matchField(dowField, dow, 0, 6)
+    );
+}
+
+/**
+ * Check if the cron schedule should fire between lastFiredAt and now.
+ * This avoids misses when heartbeat starts on-time but reaches cron phase 1-2 minutes later.
+ */
+function shouldFire(cronExpr: string, timezone: string, lastFiredAt: string | null): boolean {
+    const now = new Date();
+    const nowMinute = new Date(now);
+    nowMinute.setSeconds(0, 0);
+
+    const fallbackWindowMinutes = 5;
+    const maxScanMinutes = 24 * 60;
+
+    let windowStart =
+        lastFiredAt ?
+            new Date(new Date(lastFiredAt).getTime() + 60_000)
+        :   new Date(nowMinute.getTime() - fallbackWindowMinutes * 60_000);
+
+    windowStart.setSeconds(0, 0);
+
+    const maxWindowStart = new Date(nowMinute.getTime() - maxScanMinutes * 60_000);
+    if (windowStart < maxWindowStart) {
+        windowStart = maxWindowStart;
     }
 
-    return true;
+    if (windowStart > nowMinute) return false;
+
+    for (
+        let ts = windowStart.getTime();
+        ts <= nowMinute.getTime();
+        ts += 60_000
+    ) {
+        if (matchesCronAt(cronExpr, timezone, new Date(ts))) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /** Match a single cron field against a value */
@@ -90,18 +113,7 @@ function computeNextFireAt(cronExpr: string, timezone: string): Date {
 
     for (let i = 1; i <= maxIterations; i++) {
         const candidate = new Date(now.getTime() + i * 60_000);
-        const formatter = new Intl.DateTimeFormat('en-US', {
-            timeZone: timezone,
-            hour: 'numeric',
-            minute: 'numeric',
-            weekday: 'short',
-            day: 'numeric',
-            month: 'numeric',
-            hour12: false,
-        });
-        const parts = Object.fromEntries(
-            formatter.formatToParts(candidate).map(p => [p.type, p.value])
-        );
+        const parts = getTimeParts(candidate, timezone);
 
         const min = parseInt(parts.minute ?? '0');
         const hour = parseInt(parts.hour ?? '0');

--- a/tests/cron-seed-migration.test.ts
+++ b/tests/cron-seed-migration.test.ts
@@ -42,6 +42,17 @@ describe('017_seed_cron_schedules.sql', () => {
     expect(guardMatches.length).toBe(12);
   });
 
+  test('migration 021 enforces unique schedule names', () => {
+    const sql021 = fs.readFileSync(
+      path.join(WORKSPACE_ROOT, 'db/migrations/021_enforce_unique_cron_schedule_names.sql'),
+      'utf8',
+    );
+
+    expect(sql021).toContain('CREATE UNIQUE INDEX IF NOT EXISTS uq_ops_cron_schedules_name');
+    expect(sql021).toContain('ON ops_cron_schedules (name);');
+    expect(sql021).toContain('ROW_NUMBER() OVER');
+  });
+
   test('job names match the source of truth list', () => {
     const sql = readSql();
     const nameMatches = sql.match(/SELECT '([^']+)', '[^']+', '[^']+'/g) ?? [];


### PR DESCRIPTION
## Summary
- make the host heartbeat runner call the app through `docker compose exec` with the configured `CRON_SECRET`, removing brittle container/IP assumptions
- change cron evaluation to scan the missed-minute window so schedules still fire when heartbeat execution drifts past the scheduled minute
- deduplicate legacy `ops_cron_schedules` rows, enforce unique schedule names, and make the cron backfill script upsert safely under the new uniqueness constraint

## Verification
- `bun test tests/cron-seed-migration.test.ts`
- `npx tsc --noEmit` *(fails in current repo because `bun:test` types are not available to the project typecheck path)*
- `npm run lint` *(fails on pre-existing repo-wide lint issues unrelated to this change)*
